### PR TITLE
update docs example for infinite local records

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ import Ember from 'ember';
 import pagedArray from 'ember-cli-pagination/computed/paged-array';
 
 export default Ember.ArrayController.extend({
-  pagedContent: pagedArray('content', {infinite: "unpaged"}),
+  pagedContent: pagedArray('content', {infinite: "unpaged", perPage: 10}),
 
   actions: {
     loadNext: function() {


### PR DESCRIPTION
Include `perPage` param usage in infinite pagination example. 
The usage of `perPage` here differs from earlier examples where `perPageBinding` is used instead, and info on using the `perPage` param like this comes _after_ this example, so it may not have been read yet.
